### PR TITLE
Setup cron for starting Meteor process in case it crashed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle/*
 *.tgz
+.log/*

--- a/script/start.sh
+++ b/script/start.sh
@@ -13,24 +13,31 @@ fi
 already_running=$(ps aux | grep "node .bundle/main.js" | grep -v "grep")
 if [ "$already_running" ]
 then
-  # Extract process id from grepped process list
+  # Extract and output process id from grepped process list
   process_id=$(echo $already_running | cut -d " " -f 2)
-  # Carry on, but show an OK message
   echo "App already running [$process_id]"
 else
-  echo "Starting app..."
   # Check if this is ran from the project folder directly and go to it
   # otherwise
   in_app_folder=$(ls -a | grep ".bundle")
   if [ ! "$in_app_folder" ]
   then
     cd /var/www/aufond
-    # Assume the script is called by the cron job and log that app was crashed
-    # at that time
-    echo "$(date) App was not running and had to be started" >> .log/crash
   fi
 
+  # Make sure .log folder exists
+  if [ ! -d ".log" ]
+  then
+    echo "Creating .log folder..."
+    mkdir .log
+  fi
+
+  # Log whenever we start the app (useful for when it crashes and is started
+  # automatically from a cronjob)
+  echo "$(date) App was not running and had to be started" >> .log/crash
+
   # Start Aufond app with all required parameters
+  echo "Starting app..."
   PORT=$port \
   MONGO_URL=mongodb://aufond:aufond.mongodb@dharma.mongohq.com:10042/aufond \
   ROOT_URL=http://aufond.me:$port \

--- a/script/start.sh
+++ b/script/start.sh
@@ -9,8 +9,8 @@ then
   echo "Setting app for port $port..."
 fi
 
-# Check if Meteor (node) app is still running
-already_running=$(ps aux | grep "node .bundle/main.js" | grep -v "grep")
+# Check if a process is already running on the requested port
+already_running=$(lsof -i :$port | grep LISTEN)
 if [ "$already_running" ]
 then
   # Extract and output process id from grepped process list

--- a/script/start.sh
+++ b/script/start.sh
@@ -34,7 +34,7 @@ else
 
   # Log whenever we start the app (useful for when it crashes and is started
   # automatically from a cronjob)
-  echo "$(date) App was not running and had to be started" >> .log/crash
+  echo "$(date) App started on port $port" >> .log/start
 
   # Start Aufond app with all required parameters
   echo "Starting app..."

--- a/script/start.sh
+++ b/script/start.sh
@@ -6,9 +6,33 @@ port=3000
 if [ "$1" ]
 then
   port=$1
+  echo "Setting app for port $port..."
 fi
 
-PORT=$port \
-MONGO_URL=mongodb://aufond:aufond.mongodb@dharma.mongohq.com:10042/aufond \
-ROOT_URL=http://aufond.me:$port \
-node .bundle/main.js
+# Check if Meteor (node) app is still running
+already_running=$(ps aux | grep "node .bundle/main.js" | grep -v "grep")
+if [ "$already_running" ]
+then
+  # Extract process id from grepped process list
+  process_id=$(echo $already_running | cut -d " " -f 2)
+  # Carry on, but show an OK message
+  echo "App already running [$process_id]"
+else
+  echo "Starting app..."
+  # Check if this is ran from the project folder directly and go to it
+  # otherwise
+  in_app_folder=$(ls -a | grep ".bundle")
+  if [ ! "$in_app_folder" ]
+  then
+    cd /var/www/aufond
+    # Assume the script is called by the cron job and log that app was crashed
+    # at that time
+    echo "$(date) App was not running and had to be started" >> .log/crash
+  fi
+
+  # Start Aufond app with all required parameters
+  PORT=$port \
+  MONGO_URL=mongodb://aufond:aufond.mongodb@dharma.mongohq.com:10042/aufond \
+  ROOT_URL=http://aufond.me:$port \
+  nohup node .bundle/main.js > .log/output &
+fi

--- a/script/start.sh
+++ b/script/start.sh
@@ -41,5 +41,5 @@ else
   PORT=$port \
   MONGO_URL=mongodb://aufond:aufond.mongodb@dharma.mongohq.com:10042/aufond \
   ROOT_URL=http://aufond.me:$port \
-  nohup node .bundle/main.js > .log/output 2> .log/output &
+  nohup /usr/local/bin/node .bundle/main.js > .log/output 2> .log/output &
 fi

--- a/script/start.sh
+++ b/script/start.sh
@@ -41,5 +41,5 @@ else
   PORT=$port \
   MONGO_URL=mongodb://aufond:aufond.mongodb@dharma.mongohq.com:10042/aufond \
   ROOT_URL=http://aufond.me:$port \
-  nohup node .bundle/main.js > .log/output &
+  nohup node .bundle/main.js > .log/output 2> .log/output &
 fi


### PR DESCRIPTION
- [x] Make start.sh script look for a running process of the same kind and ignore it if exists
- [x] Log whenever start.sh script starts the process
- [x] Create cronjob that runs this script every one minute
- [x] Allow starting more instances at the same time (ignore current processes if starting on other than the default port)
