### PR TITLE
Build marketing feedback quiz

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -10,3 +10,4 @@ jquery
 less
 accounts-password
 email
+random

--- a/client/controller/front.html
+++ b/client/controller/front.html
@@ -36,61 +36,7 @@
       </div>
     </div>
     <div class="inner-wrapper">
-      <h2>Help validate this idea</h2>
-      <ul class="feedback-list">
-        <li>
-          <span class="pull-right">
-            <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-            <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-          </span>
-          <span class="title">Is this something you want?</span>
-        </li>
-      </ul>
-      <h2>What would you like to see next?</h2>
-      <ul class="feedback-list">
-        <li>
-          <span class="pull-right">
-            <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-            <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-          </span>
-          More types of media besides text and images?
-        </li>
-        <li>
-          <span class="pull-right">
-            <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-            <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-          </span>
-          A more customizable layout or styling?
-        </li>
-        <li>
-          <span class="pull-right">
-            <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-            <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-          </span>
-          Making the navigation more obvious?
-        </li>
-        <li>
-          <span class="pull-right">
-            <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-            <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-          </span>
-          Offline exporting options?
-        </li>
-        <li>
-          <span class="pull-right">
-            <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-            <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-          </span>
-          Importing content from external platforms
-        </li>
-        <li>
-          <span class="pull-right">
-            <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-            <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-          </span>
-          Maintaining and refining the current simplicity
-        </li>
-      </ul>
+      {{> feedbackQuiz}}
     </div>
     <div class="inverse disclaimer">
       <div class="inner-wrapper">

--- a/client/controller/front/feedback-quiz.coffee
+++ b/client/controller/front/feedback-quiz.coffee
@@ -3,13 +3,8 @@ Template.feedbackQuiz.events
     e.preventDefault()
     vote = new QuizVote(QuizVote.getValuesFromButtonEvent(e))
     vote.save (error, model) ->
-      # TODO: Update template with voted values and show voting statuses in
-      # template as well
-      if error
-        console.log("Couldn't vote, sorry.")
-      else
-        QuizVote.storeVoteInSession(vote)
-        console.log("Voted, thanks!")
+      # XXX users aren't clearly notified if this fails
+      QuizVote.storeVoteInSession(vote) unless error
 
 Template.feedbackQuiz.questions = [
   "More types of media besides text and images"

--- a/client/controller/front/feedback-quiz.coffee
+++ b/client/controller/front/feedback-quiz.coffee
@@ -1,17 +1,15 @@
-getValuesFromVote = (e) ->
-  $button = $(e.currentTarget)
-  return {
-    question: $button.closest('li').find('.question').text()
-    vote: parseInt($button.data('vote'), 10)
-  }
-
 Template.feedbackQuiz.events
   'click .button-vote': (e) ->
     e.preventDefault()
-    vote = new QuizVote(getValuesFromVote(e))
+    vote = new QuizVote(QuizVote.getValuesFromButtonEvent(e))
     vote.save (error, model) ->
-      # Store vote in session and update template, account for errors
-      console.log(arguments...)
+      # TODO: Update template with voted values and show voting statuses in
+      # template as well
+      if error
+        console.log("Couldn't vote, sorry.")
+      else
+        QuizVote.storeVoteInSession(vote)
+        console.log("Voted, thanks!")
 
 Template.feedbackQuiz.questions = [
   "More types of media besides text and images"

--- a/client/controller/front/feedback-quiz.coffee
+++ b/client/controller/front/feedback-quiz.coffee
@@ -1,0 +1,8 @@
+Template.feedbackQuiz.questions = [
+  "More types of media besides text and images"
+  "A more customizable layout or styling"
+  "Making the navigation more obvious"
+  "Offline exporting options"
+  "Importing content from external platforms"
+  "Maintaining and refining the current simplicity"
+]

--- a/client/controller/front/feedback-quiz.coffee
+++ b/client/controller/front/feedback-quiz.coffee
@@ -1,3 +1,15 @@
+getValuesFromVote = (e) ->
+  $button = $(e.currentTarget)
+  question = $button.closest('li').find('.question').text()
+  vote = parseInt($button.data('vote'), 10)
+  return [question, vote]
+
+Template.feedbackQuiz.events
+  'click .button-vote': (e) ->
+    e.preventDefault()
+    [question, vote] = getValuesFromVote(e)
+    console.log(question, vote)
+
 Template.feedbackQuiz.questions = [
   "More types of media besides text and images"
   "A more customizable layout or styling"

--- a/client/controller/front/feedback-quiz.coffee
+++ b/client/controller/front/feedback-quiz.coffee
@@ -14,3 +14,7 @@ Template.feedbackQuiz.questions = [
   "Offline exporting options"
   "Maintaining and refining the current simplicity"
 ]
+
+Template.feedbackQuiz.userVotedQuestion = (question, vote) ->
+  votedQuestions = QuizVote.getVotesFromSession()
+  return votedQuestions[question] is vote

--- a/client/controller/front/feedback-quiz.coffee
+++ b/client/controller/front/feedback-quiz.coffee
@@ -15,7 +15,7 @@ Template.feedbackQuiz.questions = [
   "More types of media besides text and images"
   "A more customizable layout or styling"
   "Making the navigation more obvious"
-  "Offline exporting options"
   "Importing content from external platforms"
+  "Offline exporting options"
   "Maintaining and refining the current simplicity"
 ]

--- a/client/controller/front/feedback-quiz.coffee
+++ b/client/controller/front/feedback-quiz.coffee
@@ -1,14 +1,17 @@
 getValuesFromVote = (e) ->
   $button = $(e.currentTarget)
-  question = $button.closest('li').find('.question').text()
-  vote = parseInt($button.data('vote'), 10)
-  return [question, vote]
+  return {
+    question: $button.closest('li').find('.question').text()
+    vote: parseInt($button.data('vote'), 10)
+  }
 
 Template.feedbackQuiz.events
   'click .button-vote': (e) ->
     e.preventDefault()
-    [question, vote] = getValuesFromVote(e)
-    console.log(question, vote)
+    vote = new QuizVote(getValuesFromVote(e))
+    vote.save (error, model) ->
+      # Store vote in session and update template, account for errors
+      console.log(arguments...)
 
 Template.feedbackQuiz.questions = [
   "More types of media besides text and images"

--- a/client/controller/front/feedback-quiz.html
+++ b/client/controller/front/feedback-quiz.html
@@ -1,0 +1,57 @@
+<template name="feedbackQuiz">
+  <h2>Help validate this idea</h2>
+  <ul class="feedback-list">
+    <li>
+      <span class="pull-right">
+        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+      </span>
+      <span class="title">Is this something you want?</span>
+    </li>
+  </ul>
+  <h2>What would you like to see next?</h2>
+  <ul class="feedback-list">
+    <li>
+      <span class="pull-right">
+        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+      </span>
+      More types of media besides text and images?
+    </li>
+    <li>
+      <span class="pull-right">
+        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+      </span>
+      A more customizable layout or styling?
+    </li>
+    <li>
+      <span class="pull-right">
+        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+      </span>
+      Making the navigation more obvious?
+    </li>
+    <li>
+      <span class="pull-right">
+        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+      </span>
+      Offline exporting options?
+    </li>
+    <li>
+      <span class="pull-right">
+        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+      </span>
+      Importing content from external platforms
+    </li>
+    <li>
+      <span class="pull-right">
+        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+      </span>
+      Maintaining and refining the current simplicity
+    </li>
+  </ul>
+</template>

--- a/client/controller/front/feedback-quiz.html
+++ b/client/controller/front/feedback-quiz.html
@@ -3,15 +3,15 @@
   <ul class="feedback-list">
     <li>
       <span class="pull-right">
-        {{#if userVotedQuestion "Is this something you want?" -1}}
+        {{#if userVotedQuestion "Is this something you want?" false}}
           <span class="pressed-button button-inline"><i class="icon-thumbs-down"></i></span>
         {{else}}
-          <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
+          <a href="#down" class="button button-inline button-danger button-vote" data-vote="false"><i class="icon-thumbs-down"></i></a>
         {{/if}}
-        {{#if userVotedQuestion "Is this something you want?" 1}}
+        {{#if userVotedQuestion "Is this something you want?" true}}
           <span class="pressed-button button-inline"><i class="icon-thumbs-up"></i></span>
         {{else}}
-          <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
+          <a href="#up" class="button button-inline button-success button-vote" data-vote="true"><i class="icon-thumbs-up"></i></a>
         {{/if}}
       </span>
       <span class="question">Is this something you want?</span>
@@ -22,15 +22,15 @@
     {{#each questions}}
       <li>
         <span class="pull-right">
-          {{#if userVotedQuestion this -1}}
+          {{#if userVotedQuestion this false}}
             <span class="pressed-button button-inline"><i class="icon-thumbs-down"></i></span>
           {{else}}
-            <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
+            <a href="#down" class="button button-inline button-danger button-vote" data-vote="false"><i class="icon-thumbs-down"></i></a>
           {{/if}}
-          {{#if userVotedQuestion this 1}}
+          {{#if userVotedQuestion this true}}
             <span class="pressed-button button-inline"><i class="icon-thumbs-up"></i></span>
           {{else}}
-            <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
+            <a href="#up" class="button button-inline button-success button-vote" data-vote="true"><i class="icon-thumbs-up"></i></a>
           {{/if}}
         </span>
         <span class="question">{{this}}</span>

--- a/client/controller/front/feedback-quiz.html
+++ b/client/controller/front/feedback-quiz.html
@@ -3,10 +3,10 @@
   <ul class="feedback-list">
     <li>
       <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+        <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
+        <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
       </span>
-      <span class="title">Is this something you want?</span>
+      <span class="question">Is this something you want?</span>
     </li>
   </ul>
   <h2>What would you like to see next?</h2>
@@ -14,10 +14,10 @@
     {{#each questions}}
       <li>
         <span class="pull-right">
-          <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-          <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+          <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
+          <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
         </span>
-        {{this}}
+        <span class="question">{{this}}</span>
       </li>
     {{/each}}
   </ul>

--- a/client/controller/front/feedback-quiz.html
+++ b/client/controller/front/feedback-quiz.html
@@ -11,47 +11,14 @@
   </ul>
   <h2>What would you like to see next?</h2>
   <ul class="feedback-list">
-    <li>
-      <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-      </span>
-      More types of media besides text and images?
-    </li>
-    <li>
-      <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-      </span>
-      A more customizable layout or styling?
-    </li>
-    <li>
-      <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-      </span>
-      Making the navigation more obvious?
-    </li>
-    <li>
-      <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-      </span>
-      Offline exporting options?
-    </li>
-    <li>
-      <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-      </span>
-      Importing content from external platforms
-    </li>
-    <li>
-      <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
-      </span>
-      Maintaining and refining the current simplicity
-    </li>
+    {{#each questions}}
+      <li>
+        <span class="pull-right">
+          <a href="#down" class="button button-inline button-danger"><i class="icon-thumbs-down"></i></a>
+          <a href="#up" class="button button-inline button-success"><i class="icon-thumbs-up"></i></a>
+        </span>
+        {{this}}
+      </li>
+    {{/each}}
   </ul>
 </template>

--- a/client/controller/front/feedback-quiz.html
+++ b/client/controller/front/feedback-quiz.html
@@ -3,8 +3,16 @@
   <ul class="feedback-list">
     <li>
       <span class="pull-right">
-        <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
-        <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
+        {{#if userVotedQuestion "Is this something you want?" -1}}
+          <span class="pressed-button button-inline"><i class="icon-thumbs-down"></i></span>
+        {{else}}
+          <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
+        {{/if}}
+        {{#if userVotedQuestion "Is this something you want?" 1}}
+          <span class="pressed-button button-inline"><i class="icon-thumbs-up"></i></span>
+        {{else}}
+          <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
+        {{/if}}
       </span>
       <span class="question">Is this something you want?</span>
     </li>
@@ -14,8 +22,16 @@
     {{#each questions}}
       <li>
         <span class="pull-right">
-          <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
-          <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
+          {{#if userVotedQuestion this -1}}
+            <span class="pressed-button button-inline"><i class="icon-thumbs-down"></i></span>
+          {{else}}
+            <a href="#down" class="button button-inline button-danger button-vote" data-vote="-1"><i class="icon-thumbs-down"></i></a>
+          {{/if}}
+          {{#if userVotedQuestion this 1}}
+            <span class="pressed-button button-inline"><i class="icon-thumbs-up"></i></span>
+          {{else}}
+            <a href="#up" class="button button-inline button-success button-vote" data-vote="+1"><i class="icon-thumbs-up"></i></a>
+          {{/if}}
         </span>
         <span class="question">{{this}}</span>
       </li>

--- a/client/lib/external/jquery.cookie.js
+++ b/client/lib/external/jquery.cookie.js
@@ -1,0 +1,95 @@
+/*!
+ * jQuery Cookie Plugin v1.3.1
+ * https://github.com/carhartl/jquery-cookie
+ *
+ * Copyright 2013 Klaus Hartl
+ * Released under the MIT license
+ */
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as anonymous module.
+		define(['jquery'], factory);
+	} else {
+		// Browser globals.
+		factory(jQuery);
+	}
+}(function ($) {
+
+	var pluses = /\+/g;
+
+	function raw(s) {
+		return s;
+	}
+
+	function decoded(s) {
+		return decodeURIComponent(s.replace(pluses, ' '));
+	}
+
+	function converted(s) {
+		if (s.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape
+			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+		try {
+			return config.json ? JSON.parse(s) : s;
+		} catch(er) {}
+	}
+
+	var config = $.cookie = function (key, value, options) {
+
+		// write
+		if (value !== undefined) {
+			options = $.extend({}, config.defaults, options);
+
+			if (typeof options.expires === 'number') {
+				var days = options.expires, t = options.expires = new Date();
+				t.setDate(t.getDate() + days);
+			}
+
+			value = config.json ? JSON.stringify(value) : String(value);
+
+			return (document.cookie = [
+				config.raw ? key : encodeURIComponent(key),
+				'=',
+				config.raw ? value : encodeURIComponent(value),
+				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+				options.path    ? '; path=' + options.path : '',
+				options.domain  ? '; domain=' + options.domain : '',
+				options.secure  ? '; secure' : ''
+			].join(''));
+		}
+
+		// read
+		var decode = config.raw ? raw : decoded;
+		var cookies = document.cookie.split('; ');
+		var result = key ? undefined : {};
+		for (var i = 0, l = cookies.length; i < l; i++) {
+			var parts = cookies[i].split('=');
+			var name = decode(parts.shift());
+			var cookie = decode(parts.join('='));
+
+			if (key && key === name) {
+				result = converted(cookie);
+				break;
+			}
+
+			if (!key) {
+				result[name] = converted(cookie);
+			}
+		}
+
+		return result;
+	};
+
+	config.defaults = {};
+
+	$.removeCookie = function (key, options) {
+		if ($.cookie(key) !== undefined) {
+			// Must not alter options, thus extending a fresh object...
+			$.cookie(key, '', $.extend({}, options, { expires: -1 }));
+			return true;
+		}
+		return false;
+	};
+
+}));

--- a/client/style/front.less
+++ b/client/style/front.less
@@ -90,6 +90,14 @@
           background: @color-background;
         }
       }
+      // Emulate the occupied space and font size of a small-sized button
+      .pressed-button {
+        width: 34px;
+        height: 32px;
+        font-size: 14px;
+        line-height: 32px;
+        text-align: center;
+      }
     }
     .disclaimer {
       p {

--- a/client/style/front.less
+++ b/client/style/front.less
@@ -87,7 +87,7 @@
           content: '\f105';
         }
         &:hover {
-          background: @color-background;
+          background: #f1f1f1;
         }
       }
       // Emulate the occupied space and font size of a small-sized button

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -10,12 +10,12 @@ class @QuizVote extends MeteorModel
     vote: $button.data('vote')
 
   @getVotesFromSession: ->
-    return Session.get('votedQuizQuestions') or {}
+    return Session.get('quizVotes') or {}
 
   @storeVoteInSession: (vote) ->
     votes = @getVotesFromSession()
     votes[vote.get('question')] = vote.get('vote')
-    Session.set('votedQuizQuestions', votes)
+    Session.set('quizVotes', votes)
 
   @publish: ->
     # Don't publish quiz votes at all, they are write-only

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -6,7 +6,8 @@ class @QuizVote extends MeteorModel
     $button = $(e.currentTarget)
     # Return
     question: $button.closest('li').find('.question').text()
-    vote: parseInt($button.data('vote'), 10)
+    # jQuery automatically converts "true/false" strings into Boolean
+    vote: $button.data('vote')
 
   @getVotesFromSession: ->
     return Session.get('votedQuizQuestions') or {}

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -2,6 +2,20 @@ class @QuizVote extends MeteorModel
   @collection: MeteorCollection
   @mongoCollection: new Meteor.Collection 'quizVotes'
 
+  @getValuesFromButtonEvent: (e) ->
+    $button = $(e.currentTarget)
+    # Return
+    question: $button.closest('li').find('.question').text()
+    vote: parseInt($button.data('vote'), 10)
+
+  @getVotesFromSession: ->
+    return Session.get('votedQuizQuestions') or {}
+
+  @storeVoteInSession: (vote) ->
+    votes = @getVotesFromSession()
+    votes[vote.get('question')] = vote.get('vote')
+    Session.set('votedQuizQuestions', votes)
+
   @publish: ->
     # Don't publish quiz votes at all, they are write-only
 

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -1,0 +1,32 @@
+class @QuizVote extends MeteorModel
+  @collection: MeteorCollection
+  @mongoCollection: new Meteor.Collection 'quizVotes'
+
+  @publish: ->
+    # Don't publish quiz votes at all, they are write-only
+
+  @allow: ->
+    return unless Meteor.isServer
+
+    @mongoCollection.allow
+      insert: (userId, doc) ->
+        # Allow anybody to vote on quiz questions
+        # XXX is there anything to do here to prevent spammers?
+        return true
+      update: (userId, doc, fields, modifier) ->
+        # For now quiz votes should remain unaltered
+        return false
+      remove: (userId, doc) =>
+        # For now quiz votes should remain unaltered
+        return false
+
+  save: ->
+    # Attach the creating time and the user browser agent for better stats
+    @update
+      createdAt: Date.now()
+      userAgent: navigator?.userAgent
+    super(arguments...)
+
+
+QuizVote.publish('quizVotes')
+QuizVote.allow()

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -12,6 +12,7 @@ class @QuizVote extends MeteorModel
       insert: (userId, doc) ->
         # Allow anybody to vote on quiz questions
         # XXX is there anything to do here to prevent spammers?
+        # Check out https://github.com/tmeasday/meteor-accounts-anonymous
         return true
       update: (userId, doc, fields, modifier) ->
         # For now quiz votes should remain unaltered

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -53,6 +53,7 @@ class @QuizVote extends MeteorModel
       # Most users will not be logged in when they vote, but if some do it
       # would be very interesting to put a face to their votes
       createdBy: Meteor.userId()
+      createdByGuestId: User.getGuestId()
       createdByUserAgent: navigator?.userAgent
     super(arguments...)
 

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -36,10 +36,13 @@ class @QuizVote extends MeteorModel
         return false
 
   save: ->
-    # Attach the creating time and the user browser agent for better stats
+    # Attach the creating time and user info for betters stats
     @update
       createdAt: Date.now()
-      userAgent: navigator?.userAgent
+      # Most users will not be logged in when they vote, but if some do it
+      # would be very interesting to put a face to their votes
+      createdBy: Meteor.userId()
+      createdByUserAgent: navigator?.userAgent
     super(arguments...)
 
 

--- a/model/quiz-vote.coffee
+++ b/model/quiz-vote.coffee
@@ -16,6 +16,16 @@ class @QuizVote extends MeteorModel
     votes = @getVotesFromSession()
     votes[vote.get('question')] = vote.get('vote')
     Session.set('quizVotes', votes)
+    # Store session votes to cookie as well, to persist beyond the current
+    # session
+    @storeVotesInCookie(votes)
+
+  @getVotesFromCookie: ->
+    cookieVotes = $.cookie('quizVotes')
+    return if cookieVotes then JSON.parse(cookieVotes) else {}
+
+  @storeVotesInCookie: (votes) ->
+    $.cookie('quizVotes', JSON.stringify(votes), expires: 365)
 
   @publish: ->
     # Don't publish quiz votes at all, they are write-only
@@ -49,3 +59,8 @@ class @QuizVote extends MeteorModel
 
 QuizVote.publish('quizVotes')
 QuizVote.allow()
+
+if Meteor.isClient
+  Meteor.startup ->
+    # Load votes from cookie to current session when starting app
+    Session.set('quizVotes', QuizVote.getVotesFromCookie())

--- a/model/user.coffee
+++ b/model/user.coffee
@@ -2,6 +2,18 @@ class @User extends MeteorModel
   @collection: MeteorCollection
   @mongoCollection: Meteor.users
 
+  @initGuestId: ->
+    ###
+      Plant a unique id inside a cookie for each visitor, in order to create a
+      virtual identity that persists between sessions of guest users. Useful
+      for tracking actions of not logged-in users
+    ###
+    unless $.cookie('guestId')
+      $.cookie('guestId', Random.id(), expires: 365)
+
+  @getGuestId: ->
+    return $.cookie('guestId')
+
   @remove: (id, exportToEmail = true) ->
     user = User.find(id)
     return unless user?
@@ -162,9 +174,11 @@ class @User extends MeteorModel
 User.publish()
 User.allow()
 
-
-# Generic callback for having the current user at hand
 if Meteor.isClient
+  Meteor.startup ->
+    User.initGuestId()
+
+  # Generic callback for having the current user at hand
   Deps.autorun ->
     user = User.current()
     return unless user


### PR DESCRIPTION
- [x] Create separate template for quiz (so it can render reactively by itself)
- [x] Move quiz questions from template to variables
- [x] Map events to down/up buttons and catch the quiz entry in question by extracting the text from the parent container ($.fn.text), might need to add extra markup
- [x] Create Quiz model with
  - text (field name not set in stones)
  - vote (-1 or +1)
  - votedAt
  - ~~IP~~ Ignore for now, check out https://github.com/tmeasday/meteor-accounts-anonymous later
- [x] Create Quiz entry whenever clicking down/up buttons
- [x] ~~Add feedback quiz tab in admin (like user tab, only for admin)~~ They can be read in the mongohq interface for now
- [x] Also store the voted questions in Session (better than cookie because it's reactive and template can be built around it)
  - Find structure, maybe a .toJSON Quiz model
- [x] Add userId to QuizVotes if logged in (this way you can match user emails and announce if you met their wishes)
- [x] Find a different way to display voted questions by relying on reactive rendering based on Session (design, styling involved)
- [x] Store Session.votedQuizQuestions in cookie for persistance?
- [x] Add a guessUserId generated when creating cookie that persists in the db -- people might play too much with the buttons and the stats become irrelevant if we can't match them per user (be it guest user)
- [x] Make finishing touches to styling (like hover color)
