### PR TITLE
Create Rackspace image with all packages installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,18 @@
 Installation Guide
 ======
-For Debian 7 (Wheezy)
+Tested on Debian 7 (Wheezy)
 
 ```bash
-# Setup user
-useradd -m -s /bin/bash skidding
-passwd skidding
-apt-get -y install sudo
-apt-get -y install vim
-export EDITOR=vim
-visudo
-skidding ALL=(ALL) ALL
-su skidding
-mkdir ~/.ssh
-echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2fDBGRaDOXvGGbUCuAE6GVMI2Aj/FS5RxvYv9uOATkV1dD/EU/3y3q0KXQgGpz6FX/GqGr4S9QdqQFvy1/9I9sZxkNK23+snTSKz9Nr3Q1Vtp0e0lKp8FIdz5XM5k58EpEiW28JJW8Vpsym8KtzbCH3LIsE78zB2Uql0mlRXQFIfm9iE6U08JhCUs+OgCf9PiCD1faSxgSOF67pMsAIVS55SmBPPQNsSa2kvWMrReNgRMaIsCkwLAmMC1gd/JO2EQaS0W2sZ3SK+FxAYcLph/9MMmn1Guly9iGuUHmf0pAk0dMLo1k6a+tBVgAF3I5kTdhLQ6aBa/Pp+elJ2rO5lr ovidiu@Ovidius-MacBook-Air.local" >> ~/.ssh/authorized_keys
+# Where the project will be situated
+mkdir -p /var/www/aufond
+
+# We need to install Git and fetch the private repo for the install script
+aptitude install -y git && git clone https://github.com/skidding/aufond.git /var/www/aufond
 
 # Setup project
-sudo mkdir /var/www
-sudo chown skidding:skidding /var/www
-sudo apt-get -y install git
-sudo apt-get -y install build-essential
-sudo apt-get -y install curl
-cd /var/www
-git clone https://github.com/joyent/node.git
-cd node
-./configure && make && sudo make install
-cd /var/www
-git clone https://github.com/skidding/aufond.git
-curl https://install.meteor.com | /bin/sh
-cd aufond
-script/bundle.sh
-script/start.sh
-
-# Set vim as permanent user editor
-vim ~/.bashrc
-export EDITOR=vim
+cd /var/www/aufond && script/install.sh
 
 # Add cronjob to start project in case it crashes
 crontab -e
 */1 * * * * /var/www/aufond/script/start.sh
-
-# Set project path the default login path of the user
-vim ~/.bashrc
-cd /var/www/aufond
 ```

--- a/script/install.sh
+++ b/script/install.sh
@@ -14,6 +14,7 @@ aptitude install -y vim curl build-essential
 echo "Installing Node..."
 git clone https://github.com/joyent/node.git /var/www/node
 cd /var/www/node
+git checkout v0.10.11
 ./configure && make && make install
 cd -
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -14,7 +14,7 @@ aptitude install -y vim curl build-essential
 echo "Installing Node..."
 git clone https://github.com/joyent/node.git /var/www/node
 cd /var/www/node
-./configure && make && sudo make install
+./configure && make && make install
 cd -
 
 echo "Installing Meteor..."

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,0 +1,28 @@
+#/bin/bash
+
+echo "Setting up user SSH key..."
+mkdir -p ~/.ssh
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2fDBGRaDOXvGGbUCuAE6GVMI2Aj/FS5RxvYv9uOATkV1dD/EU/3y3q0KXQgGpz6FX/GqGr4S9QdqQFvy1/9I9sZxkNK23+snTSKz9Nr3Q1Vtp0e0lKp8FIdz5XM5k58EpEiW28JJW8Vpsym8KtzbCH3LIsE78zB2Uql0mlRXQFIfm9iE6U08JhCUs+OgCf9PiCD1faSxgSOF67pMsAIVS55SmBPPQNsSa2kvWMrReNgRMaIsCkwLAmMC1gd/JO2EQaS0W2sZ3SK+FxAYcLph/9MMmn1Guly9iGuUHmf0pAk0dMLo1k6a+tBVgAF3I5kTdhLQ6aBa/Pp+elJ2rO5lr ovidiu@Ovidius-MacBook-Air.local" >> ~/.ssh/authorized_keys
+
+echo "Setting up .bashrc startup commands for user..."
+echo "export EDITOR=vim" >> ~/.bashrc
+echo "cd /var/www/aufond" >> ~/.bashrc
+
+echo "Installing required packages..."
+aptitude install -y vim curl build-essential
+
+echo "Installing Node..."
+git clone https://github.com/joyent/node.git /var/www/node
+cd /var/www/node
+./configure && make && sudo make install
+cd -
+
+echo "Installing Meteor..."
+curl https://install.meteor.com | /bin/sh
+
+echo "Creating initial bundle..."
+script/bundle.sh
+
+echo "Project ready! Run script/start.sh to start it."
+# Prepare vim editor for setting up cron w/out having to log out and in again
+export EDITOR=vim


### PR DESCRIPTION
- [x] Put default editor and default path from put ~/.bashrc next to each other, and put them in user creation part of the installation guide
- [x] Turn installation guide into an install script, the guide should have as little instructions as possible
  - drop the user, over-complication for now because we still need to run it with root for 80 port
  - `apt-get install -y git`
  - `mkdir /var/www && cd /var/www`
  - `git clone https://github.com/skidding/aufond.git && cd aufond`
  - `script/install.sh`
- [x] Create install.sh script with the rest of the instructions and test it
- [x] Create rackspace image after the script runs flawlessly
- [x] Close Turtle instance 
