### PR TITLE
Add front-admin session communication

### DIFF
--- a/client/controller/admin.coffee
+++ b/client/controller/admin.coffee
@@ -1,18 +1,4 @@
 Template.admin.events
-  'click .button-timeline': (e) ->
-    e.preventDefault()
-    username = Meteor.user().username
-    App.router.navigate("#{username}", trigger: true)
-
-  'click .button-logout': (e) ->
-    e.preventDefault()
-
-    # Track signouts in Mixpanel
-    username = Meteor.user()?.username
-    mixpanel.track('logout', username: username)
-
-    User.logout()
-
   'click .button-post': (e) ->
     e.preventDefault()
     data = $(e.currentTarget).data()

--- a/client/controller/admin.html
+++ b/client/controller/admin.html
@@ -1,13 +1,5 @@
 <template name="admin">
-  <div class="header">
-    <div class="inner-wrapper">
-      <div class="pull-right">
-        <a href="#timeline" class="button button-inline button-xlarge button-timeline">Timeline</a>
-        <a href="#logout" class="button button-inline button-xlarge button-inverse button-logout"><i class="icon-off"></i></a>
-      </div>
-      <h1><strong>aufond</strong>.me</h1>
-    </div>
-  </div>
+  {{> header}}
   <div class="inner-wrapper">
     {{> adminTabs}}
     <div class="tab-content">

--- a/client/controller/front.coffee
+++ b/client/controller/front.coffee
@@ -1,14 +1,4 @@
 Template.front.events
-  'click .button-register': (e) ->
-    e.preventDefault()
-    data = $(e.currentTarget).data()
-    App.registerModal.update(data)
-
-  'click .button-login': (e) ->
-    e.preventDefault()
-    data = $(e.currentTarget).data()
-    App.loginModal.update(data)
-
   'click .button-demo': (e) ->
     e.preventDefault()
     # Scroll to top before opening timeline, in order to land the timeline

--- a/client/controller/front.html
+++ b/client/controller/front.html
@@ -1,13 +1,5 @@
 <template name="front">
-  <div class="header">
-    <div class="inner-wrapper">
-      <div class="pull-right">
-        <a href="#register" class="button button-inline button-success button-xlarge button-register" data-toggle="modal" data-target="#register-modal" data-title="Why hi there!" data-button="Count me in"><strong>Instant Beta</strong></a>
-        <a href="#login" class="button button-inline button-xlarge button-login" data-toggle="modal" data-target="#login-modal" data-title="Good day!" data-button="Let me in">Login</a>
-      </div>
-      <h1><strong>aufond</strong>.me</h1>
-    </div>
-  </div>
+  {{> header}}
   <div class="demo">
     <div class="action-bar">
       <div class="inner-wrapper">

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -1,0 +1,27 @@
+Template.header.events
+  'click .button-register': (e) ->
+    e.preventDefault()
+    App.registerModal.update($(e.currentTarget).data())
+
+  'click .button-login': (e) ->
+    e.preventDefault()
+    App.loginModal.update($(e.currentTarget).data())
+
+  'click .button-timeline': (e) ->
+    e.preventDefault()
+    username = Meteor.user().username
+    App.router.navigate("#{username}", trigger: true)
+
+  'click .button-admin': (e) ->
+    e.preventDefault()
+    App.router.navigate('admin', trigger: true)
+
+  'click .button-front': (e) ->
+    e.preventDefault()
+    App.router.navigate('', trigger: true)
+
+  'click .button-logout': (e) ->
+    e.preventDefault()
+    # Track signouts in Mixpanel
+    mixpanel.track('logout', username: Meteor.user().username)
+    User.logout()

--- a/client/header.html
+++ b/client/header.html
@@ -1,0 +1,21 @@
+<template name="header">
+  <div class="header">
+    <div class="inner-wrapper">
+      <div class="pull-right">
+        {{#if loggedIn}}
+          <a href="#timeline" class="button button-inline button-xlarge button-timeline">{{loggedIn}}</a>
+          {{#if inController "admin"}}
+            <a href="#front" class="button button-inline button-xlarge button-front"><i class="icon-reply"></i></a>
+          {{else}}
+            <a href="#admin" class="button button-inline button-xlarge button-admin"><i class="icon-cog"></i></a>
+          {{/if}}
+          <a href="#logout" class="button button-inline button-inverse button-xlarge button-logout"><i class="icon-off"></i></a>
+        {{else}}
+          <a href="#register" class="button button-inline button-success button-xlarge button-register" data-toggle="modal" data-target="#register-modal" data-title="Why hi there!" data-button="Count me in"><strong>Instant Beta</strong></a>
+          <a href="#login" class="button button-inline button-xlarge button-login" data-toggle="modal" data-target="#login-modal" data-title="Good day!" data-button="Let me in">Login</a>
+        {{/if}}
+      </div>
+      <h1><strong>aufond</strong>.me</h1>
+    </div>
+  </div>
+</template>

--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -26,5 +26,11 @@ Handlebars.registerHelper 'timeago', (time) ->
 Handlebars.registerHelper 'formatDate', (time, format) ->
   return moment(time).format(format)
 
+Handlebars.registerHelper 'loggedIn', ->
+  return Meteor.user()?.username
+
 Handlebars.registerHelper 'isRootUser', ->
   return User.current()?.isRoot()
+
+Handlebars.registerHelper 'inController', (name) ->
+  return App.router.args.name is name


### PR DESCRIPTION
One idea is two replace "Register | Login" buttons with "Hello X | Sign Out" ones, another is to let the forms but have a text inside any that says "Already logged in as X, click here to go in admin or go on registering/logging in as a different user". **Clearly the first!** `Howdy {{name.split(' ')[0] or email}} | Admin | Logout`

Also make the admin main button point to front page
