### PR TITLE
Install spiderable package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -11,3 +11,4 @@ less
 accounts-password
 email
 random
+spiderable

--- a/client/controller/timeline.coffee
+++ b/client/controller/timeline.coffee
@@ -56,11 +56,9 @@ class @Timeline
 
     # Detect the height of the header in its current state
     headerHeight = $header.find('.head').outerHeight()
-    # Set a minimum top and bottom margin of 100px
-    minTop = 100
-    # XXX add extra 50px to the bottom margin, in order for the most current
-    # year bubble to be peeking from below
-    minBottom = 150
+    # Set a minimum top and bottom margin of 150px. 50px from the bottom will
+    # go to the peeking year bubble
+    minTop = minBottom = 150
     # Only take content height into consideration if visible (when the header
     # is active)
     if $header.hasClass('active')

--- a/client/controller/timeline.coffee
+++ b/client/controller/timeline.coffee
@@ -59,7 +59,9 @@ class @Timeline
     # Only take content height into consideration if visible (when the header
     # is active)
     if $header.hasClass('active')
-      headerHeight += @getHeaderContentHeight($header)
+      # XXX subtract 60px of the content height because the avatar bubble
+      # overlaps with 60px over it
+      headerHeight += @getPostContentHeight($header) - 60
 
     # Make sure things don't overlap when the window is smaller than the header.
     # Also keep 50px for the bottom margin and 50 for the peeking year bubble
@@ -356,17 +358,6 @@ class @Timeline
     if $entry.find('.content').length
       height += $entry.find('.head').outerHeight()
     return height
-
-  @getHeaderContentHeight: ($entry) ->
-    ###
-      Calculate the exact height of the header's content section. Unless it is
-      missing, in which case it will be zero.
-
-      Don't use outerHeight() in order not to include the bottom margin, which
-      overlaps with the height of the .head
-    ###
-    return 0 unless $entry.find('.content').length
-    return $entry.find('.content .inner-wrap').height()
 
   @getPostContentHeight: ($entry) ->
     ###

--- a/client/controller/timeline.coffee
+++ b/client/controller/timeline.coffee
@@ -56,20 +56,26 @@ class @Timeline
 
     # Detect the height of the header in its current state
     headerHeight = $header.find('.head').outerHeight()
+    # Set a minimum top and bottom margin of 100px
+    minTop = 100
+    # XXX add extra 50px to the bottom margin, in order for the most current
+    # year bubble to be peeking from below
+    minBottom = 150
     # Only take content height into consideration if visible (when the header
     # is active)
     if $header.hasClass('active')
       # XXX subtract 60px of the content height because the avatar bubble
       # overlaps with 60px over it
       headerHeight += @getPostContentHeight($header) - 60
+      # No need for a min top margin when the header content is open
+      minTop = 0
 
-    # Make sure things don't overlap when the window is smaller than the header.
-    # Also keep 50px for the bottom margin and 50 for the peeking year bubble
-    windowHeight = Math.max($(window).height(), headerHeight + 100)
-
-    # Align vertically to center, while preserving the bottom padding of 100px
+    # Make sure things don't overlap when the window is smaller than the
+    # header, by enforcing the min top & bottom margins
+    windowHeight =
+      Math.max($(window).height(), headerHeight + minTop + minBottom)
     availableHeight = windowHeight - headerHeight
-    top = Math.min(availableHeight / 2, availableHeight - 100)
+    top = Math.min(availableHeight / 2, availableHeight - minBottom)
 
     # Height and padding of header entry use CSS transitions and will change
     # gracefully and in sync

--- a/client/index.html
+++ b/client/index.html
@@ -1,6 +1,7 @@
 <head>
   <title>aufond.me — a résumé for the modern age</title>
   <meta name="description" content="Your experience is a unique journey, not a set of bullet points.">
+  <meta name="fragment" content="!">
   <meta name="viewport" content="width=600,user-scalable=no">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900,200italic,300italic,400italic,600italic,700italic,900italic|Open+Sans:300italic,400italic,600italic,700italic,800italic,300,400,600,700,800&amp;subset=latin,latin-ext" rel="stylesheet" type="text/css">

--- a/model/user.coffee
+++ b/model/user.coffee
@@ -72,7 +72,11 @@ class @User extends MeteorModel
 
       Meteor.publish 'userEmails', ->
         # Only make all user emails public to the root user
-        return null unless @userId and User.find(@userId).isRoot()
+        # XXX returning a null value instead of a Mongo cursor does not trigger
+        # _allSubscriptionsReady and the spiderable plugin remains hanging.
+        # Publish supports returning a list of cursors and returning an empty
+        # list seems to hit the spot
+        return [] unless @userId and User.find(@userId).isRoot()
         return User.mongoCollection.find({}, {fields: {emails: 1}})
 
     if Meteor.isClient


### PR DESCRIPTION
http://docs.meteor.com/#spiderable

Should be triggered by `?_escaped_fragment_=`
- [x] Sort out `return null` publish call that doesn't trigger Spiderable --- Find a way to return an empty cursor
- [x] ~~Check why it doesn't work in development~~ That's that, some other time
- [x] Understand `<meta name="fragment" content="!">` It's kind of stupid, `!` is the only possible value, this is the tag that indicate the crawler to try indexing the `?_escaped_fragment_=` version of the current url. If it had a hashbang it would've replaced it automatically into `_escaped_fragment_=afterhashbang`  https://developers.google.com/webmasters/ajax-crawling/docs/specification
- [x] ~~Add some default height to the header (or check if we can set a default height to the phantomjs browser)~~, more like min-padding at the bottom, equaivalent of the vertical padding of an entry
- [x] ~~Make all entries opened on _escaped_fragment_ (or a different trigger)~~ As MVP move, just load `/username/contact?_escaped_fragment_=` in the back and see what users request
