### PR TITLE
Make website crawlable

### DIFF
--- a/client/controller/timeline.coffee
+++ b/client/controller/timeline.coffee
@@ -181,7 +181,7 @@ class @Timeline
     ###
       Simulate a click on an entry
     ###
-    $entry.find('.link:first').click()
+    $entry.find('.link:first').each(-> Timeline.toggleLink(this))
 
   @goTo: (slug, animate = true) ->
     ###
@@ -271,14 +271,9 @@ class @Timeline
     if description
       $('meta[name=description]').prop('content', description)
 
-  @openLink: (e) =>
-    e.preventDefault()
-    # Stop events from bubbling up so they don't reach the timeline element,
-    # which already listens to click events and will untoggle any active entry
-    # when receiving one
-    e.stopPropagation()
+  @toggleLink: (anchor) =>
     # Toggle link path if currently on it
-    path = @getPathByTarget(e.currentTarget)
+    path = @getPathByTarget(anchor)
     if path is @getCurrentPath()
       path = @getDefaultPath()
     else
@@ -408,7 +403,13 @@ $.fn.contractEntry = ->
 
 
 Template.timeline.events
-  'click .link': Timeline.openLink
+  'click .link': (e) ->
+    e.preventDefault()
+    # Stop events from bubbling up so they don't reach the timeline element,
+    # which already listens to click events and will untoggle any active entry
+    # when receiving one
+    e.stopPropagation()
+    Timeline.toggleLink(e.currentTarget)
   # Untoggle any active entry when clicking on the timeline background,
   # outside any entry link
   'click .entries': Timeline.untoggleActiveEntry

--- a/client/controller/timeline.html
+++ b/client/controller/timeline.html
@@ -22,24 +22,24 @@
               </div>
             </div>
           {{/if}}
-          <div class="head link" data-slug="contact">
+          <a href="{{entryUrl 'contact'}}" class="head link" data-slug="contact">
             <span class="bullet" style="background-image: url('{{getResizedImageUrl avatar 120 120 'crop'}}');"></span>
             <div class="inner-wrap">
               {{{markdown name root="h1"}}}
               {{{markdown title root="p"}}}
             </div>
-          </div>
+          </a>
         </li>
       {{/match}}
       {{#match type="post"}}
         <li id="timeline-{{urlSlug}}" class="entry post {{parity index}}">
-          <div class="head link" data-slug="{{urlSlug}}">
+          <a href="{{entryUrl urlSlug}}" class="head link" data-slug="{{urlSlug}}">
             <span class="bullet {{iconClass icon}}"></span>
             <div class="inner-wrap">
               {{{markdown headline root="h2"}}}
               {{{markdown excerpt}}}
             </div>
-          </div>
+          </a>
           {{#if hasExtendedContent}}
             <div class="content">
               <div class="inner-wrap">
@@ -71,7 +71,7 @@
       {{/match}}
       {{#match type="year"}}
         <li id="timeline-{{year}}" class="entry year">
-          <span class="bullet link" data-slug="{{year}}">{{year}}</span>
+          <a href="{{entryUrl year}}" class="bullet link" data-slug="{{year}}">{{year}}</a>
         </li>
       {{/match}}
     {{/each}}

--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -34,3 +34,13 @@ Handlebars.registerHelper 'isRootUser', ->
 
 Handlebars.registerHelper 'inController', (name) ->
   return App.router.args.name is name
+
+Handlebars.registerHelper 'entryUrl', (slug) ->
+  ###
+    Create a relative (no domain) url path to a certain timeline entry.
+    The challange is knowing whether or not to add the username prefix,
+    assuming that we support user domains. XXX we don't, improve this logic
+    and make the username optional once we do
+  ###
+  username = App.router.args.username
+  return "/#{username}/#{slug}"

--- a/client/style/timeline.less
+++ b/client/style/timeline.less
@@ -69,6 +69,13 @@
     padding: 0 0 (@entry-margin - 20) 0;
     .transition(opacity, 0.2s);
 
+    // Anchor tags are used for head sections and clickable bubble, so block
+    // display and a style reset need to be enfored on them
+    .link {
+      display: block;
+      text-decoration: none;
+      color: @color-dark;
+    }
     .bullet {
       position: absolute;
       .bullet(@bullet-size-post);

--- a/model/entry.coffee
+++ b/model/entry.coffee
@@ -68,6 +68,12 @@ class @Entry extends MeteorModel
     @set('images', []) unless @get('images')?
     super(arguments...)
 
+  getUser: ->
+    ###
+      Proxy for fetching the User document of the Entry author
+    ###
+    return User.find(@get('createdBy'))
+
   addImage: (imageAttributes, callback) ->
     ###
       Attach a new image to an Entry


### PR DESCRIPTION
Since spiderable is installed, we should
- [x] Make timeline links linkable
- [x] ~~Create a wildcard robots.txt file~~ Don't need this either, the problem was that google was looking at `ovidiu.ch/robots.txt` and got redirect to `aufond.me/skidding/robots.txt`, which generates a valid timeline. `/robots.txt` is 404 by default in Meteor - See #69

```
User-agent: *
Disallow:
```
- [x] ~~See what's the current state of sitemap.xml~~ Whatever, we'll see how crawling works after putting this in prod and take it from there. Generating an XML from actual db data seems like a drag for MVP-like prioritizaton
- [x] See what's the deal with webmaster tools -- Installed, in skidding@gmail.com account
