### PR TITLE
Create exporting service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .bundle/*
 *.tgz
-.log/*

--- a/.log/.gitignore
+++ b/.log/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/public/export/.gitignore
+++ b/public/export/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/script/start.sh
+++ b/script/start.sh
@@ -1,5 +1,6 @@
 #/bin/bash
 
+hostname="aufond.me"
 port=80
 
 # The port can be specified as the first parameter
@@ -43,10 +44,22 @@ else
   # Create an unique output log for each process, helps post-crash debugging
   output_log=".log/output-$utc_time"
 
+  # Use localhost hostname in development
+  in_development="$(hostname | grep -i "ovidiu")"
+  if [ "$in_development" ]
+  then
+    hostname="localhost"
+  fi
+  # Only append port to hostname if different than 80
+  if [ $port != 80 ]
+  then
+    hostname+=":$port"
+  fi
+
   # Start aufond app with all required parameters
   echo "Starting app..."
   PORT=$port \
   MONGO_URL=mongodb://aufond:aufond.mongodb@dharma.mongohq.com:10042/aufond \
-  ROOT_URL=http://aufond.me:$port \
+  ROOT_URL=http://$hostname \
   nohup /usr/local/bin/node .bundle/main.js >> $output_log 2>> $output_log &
 fi


### PR DESCRIPTION
Makes request with ?_escaped_fragment_= in the back, extracts the css path, wgets it and replaces the tab with the entire content, so that the index doesn't depend on any external file. Then probably email it. Consider alternative delivering, like open in a new tab or send by email (check HN thread)

Also remove contents, images, and fetch avatar image and turn into data:image stuff
