### PR TITLE
Fix template change between controllers

### DIFF
--- a/client/controller.coffee
+++ b/client/controller.coffee
@@ -26,8 +26,6 @@ class @Controller extends ReactiveTemplate
     else if data.name is 'admin' and @data.name is 'admin'
       App.adminTabs.select(App.router.args.tab)
     else
-      # Add the controller name as a class on the <body> tag
-      $('body').attr('class', data.name)
       # Revert page title and description to their default values whenever
       # switching between controllers
       document.title = @defaultPageTitle

--- a/client/controller.html
+++ b/client/controller.html
@@ -1,3 +1,3 @@
 <template name="controller">
-  <div id="content"></div>
+  <div id="content" class="{{name}}"></div>
 </template>

--- a/client/style/admin.less
+++ b/client/style/admin.less
@@ -1,6 +1,6 @@
 @import "mixin.lessimport";
 
-body.admin {
+#content.admin {
   .create-button-wrapper {
     margin-bottom: 20px;
   }

--- a/client/style/front.less
+++ b/client/style/front.less
@@ -1,6 +1,6 @@
 @import "mixin.lessimport";
 
-body.front {
+#content.front {
   .demo {
     position: relative;
     height: 600px;

--- a/client/style/timeline.less
+++ b/client/style/timeline.less
@@ -23,7 +23,7 @@
 }
 
 /* Default timeline, for mobile display */
-body.timeline {
+#content.timeline {
   min-width: @entry-width-content-outer;
   background: @color-bright;
   color: @color-dark;
@@ -340,7 +340,7 @@ body.timeline {
 
 /* Timeline on larger, desktop devices */
 @media (min-width: 1206px) {
-  body.timeline {
+  #content.timeline {
     /* Odd posts stay on the right */
     .post {
       text-align: left;


### PR DESCRIPTION
Since we moved the controller CSS class to the body, it now changes before the template does, and they content from the previous controller remains un-styled for a second. Let's just move it back
