### PR TITLE
Make timeline fade out at the bottom of an exported timeline .pdf

### DIFF
--- a/client/style/print/timeline.lessimport
+++ b/client/style/print/timeline.lessimport
@@ -77,5 +77,19 @@
         top: 70px;
       }
     }
+    // Since the background color of PhantomJS pdf pages is white and we can't
+    // split the webpage into an exact number of pages, we need to account for
+    // the remaining white space from the second part of the last page. We do
+    // that by adding a smooth fade out transition after the last entry
+    .entry:last-child {
+      padding-bottom: 0;
+
+      &:after {
+        content: '';
+        display: block;
+        height: 80px;
+        .backgroundGradient(~"rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%");
+      }
+    }
   }
 }


### PR DESCRIPTION
Since we cannot yet create a single-page .pdf or split the timeline in exact pages, there will always be a white space at the bottom of the last page. There are two possibilities:
- If a background color can be set in phantomjs, fade out the timeline bar only
- If not, fade out the bg color and timeline bar altogether
